### PR TITLE
ci: disable persist-credentials

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,8 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
         with:
           aqua_version: v2.28.1
@@ -54,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
       - run: deno task fmt:check
       - run: deno task check


### PR DESCRIPTION
- **ci: specify timeout**
- **ci: disable persist-credentials**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Nix flake configuration providing formatting tools, linting checks, a packaged build, and a development environment.
* **Chores**
  * Added a 5-minute timeout to relevant GitHub Actions workflow jobs to limit execution time.
  * Improved workflow security by updating configuration settings for credential management.
  * Simplified workflow steps by removing unnecessary conditional statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->